### PR TITLE
Modifying Flags in GetEnvironmentInformation.srv

### DIFF
--- a/tesseract_ros/tesseract_msgs/srv/GetEnvironmentInformation.srv
+++ b/tesseract_ros/tesseract_msgs/srv/GetEnvironmentInformation.srv
@@ -1,20 +1,23 @@
-uint8 COMMAND_HISTORY=0             # Get the current change history
+# You can combine the requests using a bitwise OR operation (In C++, use
+# the | operator).  They are extracted from the `flags` variable using a
+# bitwise AND operator.
+uint16 COMMAND_HISTORY=1             # Get the current change history
 
-uint8 LINK_LIST=1                   # Get the current list of links
-uint8 JOINT_LIST=2                  # Get the current list of links
+uint16 LINK_LIST=2                   # Get the current list of links
+uint16 JOINT_LIST=4                  # Get the current list of links
 
-uint8 LINK_NAMES=4                  # Get the current list of links
-uint8 JOINT_NAMES=8                 # Get the current list of links
+uint16 LINK_NAMES=8                  # Get the current list of links
+uint16 JOINT_NAMES=16                # Get the current list of links
 
-uint8 ACTIVE_LINK_NAMES=16          # Get the current list of active links
-uint8 ACTIVE_JOINT_NAMES=32         # Get the current list of active joints
+uint16 ACTIVE_LINK_NAMES=32          # Get the current list of active links
+uint16 ACTIVE_JOINT_NAMES=64         # Get the current list of active joints
 
-uint8 LINK_TRANSFORMS=64            # Get the current list of link transforms
-uint8 JOINT_TRANSFORMS=128          # Get the current list of joint transforms
+uint16 LINK_TRANSFORMS=128           # Get the current list of link transforms
+uint16 JOINT_TRANSFORMS=256          # Get the current list of joint transforms
 
-uint8 ALLOWED_COLLISION_MATRIX=254  # Get the current list of joint transforms
+uint16 ALLOWED_COLLISION_MATRIX=512  # Get the current list of joint transforms
 
-uint8 flags # The flags indicating what information should be returned.
+uint16 flags # The flags indicating what information should be returned.
 ---
 bool success
 string id # Name/Id of the environment


### PR DESCRIPTION
@mpowelson I am going to cherry-pick this commit and also open a PR against the main repository.

The GetEnvironmentInformation service uses the bitwise AND operator to separate user requests and send only certain information.  However, there were two logical errors.
- First, the 'flag' for ALLOWED_COLLISION_MATRIX was 254.  254 converts to 1111 1110.  Requesting this matrix was identical to requesting everything from LINK_LIST through JOINT_TRANSFORM.  Therefore, all of those would return if the ACM was requested, and the ACM would return if any of those were requested.
- Second, the 'flag' for COMMAND_HISTORY was 0.  0 converts to 0000 0000.  Since bitwise AND between any number and 0 is 0 (which C++ translates as false), COMMAND_HISTORY was never returned.

In order to fix this:
- Changed from 8-bit ints to 16-bit ints
- Incremented all 'flag' numbers by one power of two (0->1, 1->2, 2->4, etc.)
- Added a comment to the srv file explaining how these values are used.